### PR TITLE
Use Java 22 for the GitHub CI builds.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '20' ]
+        java: [ '11', '17', '22' ]
     name: JDK ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3

--- a/koans/pom.xml
+++ b/koans/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>java-koans</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>Java Koans</name>
   <inceptionYear>2012</inceptionYear>
   <url>https://github.com/DavidWhitlock/java-koans</url>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
       <artifactId>koans-lib</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <properties>

--- a/koans/pom.xml
+++ b/koans/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
   </parent>
   <artifactId>java-koans</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <name>Java Koans</name>
   <inceptionYear>2012</inceptionYear>
   <url>https://github.com/DavidWhitlock/java-koans</url>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
       <artifactId>koans-lib</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
   <properties>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>koans-lib</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>Java Koans Framework</name>
   <url>https://github.com/DavidWhitlock/java-koans</url>
   <scm>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
   </parent>
   <artifactId>koans-lib</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <name>Java Koans Framework</name>
   <url>https://github.com/DavidWhitlock/java-koans</url>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <artifactId>koans-parent</artifactId>
   <packaging>pom</packaging>
   <name>Java Koans Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <artifactId>koans-parent</artifactId>
   <packaging>pom</packaging>
   <name>Java Koans Parent POM</name>


### PR DESCRIPTION
And while I'm at it, use the new 1.1.0 top-level POM.