### PR TITLE
Publish SNAPSHOT artifacts to Maven Central.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '22' ]
+        java: [ '21' ]
     name: JDK ${{ matrix.Java }}
     steps:
       - uses: actions/checkout@v3

--- a/koans/pom.xml
+++ b/koans/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>java-koans</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <name>Java Koans</name>
   <inceptionYear>2012</inceptionYear>
   <url>https://github.com/DavidWhitlock/java-koans</url>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
       <artifactId>koans-lib</artifactId>
-      <version>1.2.1-SNAPSHOT</version>
+      <version>1.2.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <properties>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -66,7 +66,7 @@
   <repositories>
     <repository>
       <name>Central Portal Snapshots</name>
-      <id>central</id>
+      <id>central-portal-snapshots</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
     <artifactId>koans-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
   </parent>
   <artifactId>koans-lib</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <name>Java Koans Framework</name>
   <url>https://github.com/DavidWhitlock/java-koans</url>
   <scm>
@@ -65,9 +65,9 @@
   </build>
   <repositories>
     <repository>
-      <id>maven-snapshots</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <layout>default</layout>
+      <name>Central Portal Snapshots</name>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <repositories>
     <repository>
       <name>Central Portal Snapshots</name>
-      <id>central</id>
+      <id>central-portal-snapshots</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.com.sandwich</groupId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <artifactId>koans-parent</artifactId>
   <packaging>pom</packaging>
   <name>Java Koans Parent POM</name>
@@ -18,9 +18,9 @@
 
   <repositories>
     <repository>
-      <id>maven-snapshots</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <layout>default</layout>
+      <name>Central Portal Snapshots</name>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
See JoyOfCodingPDX/JoyOfCoding#503 for why we need to migrate to Maven Central for `SNAPSHOT` artifacts.